### PR TITLE
Random shouldn't clamp sample count

### DIFF
--- a/link.js
+++ b/link.js
@@ -977,7 +977,6 @@ var Link = (function() {
 	function Random(times) {
 		if (!times) times = 1;
 		var a = this.toArray();
-		times = Math.min(times, a.length);
 		var samples = [];
 		while (times--) {
 			var i = Math.floor(Math.random() * a.length);


### PR DESCRIPTION
Since Random is allowed to repeat anyway, the clamping isn't necessary.  Just a minor issue I noticed while reviewing the recent changes.
