### PR TITLE
Add CommonJS support

### DIFF
--- a/link.js
+++ b/link.js
@@ -1405,3 +1405,9 @@ var Link = (function(undefined) {
 	
 	return Link;
 })();
+
+// CommonJS export table
+// allows the script to be loaded using require().
+if (typeof exports !== 'undefined') {
+    exports.link = Link;
+}

--- a/link.js
+++ b/link.js
@@ -1408,6 +1408,6 @@ var Link = (function(undefined) {
 
 // CommonJS export table
 // allows the script to be loaded using require().
-if (typeof exports !== 'undefined') {
-    exports.link = Link;
+if (typeof module !== 'undefined') {
+    module.exports = Link;
 }


### PR DESCRIPTION
This lets Link be loaded as a CommonJS module using `require()` in environments like Node.JS and minisphere.
